### PR TITLE
refactor(features): Step 4 chat/search を features/ へ移行

### DIFF
--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -13,8 +13,8 @@ from fastapi.responses import RedirectResponse
 import gradio as gr
 
 from app.utils.svg import make_favicon_data_uri, write_emoji_svg
-from app.chat_feature import guard_and_prep, stream_llm, stop_chat
-from app.search_feature import suggest, on_change, chips_html, neutralize_email
+from app.features.chat import guard_and_prep, stream_llm, stop_chat
+from app.features.search import suggest, on_change, chips_html, neutralize_email
 from app.db.bootstrap import bootstrap_schema_and_seed
 from app.db.session import db_session
 from app.repositories.thread_repo import ThreadRepository

--- a/app/features/chat.py
+++ b/app/features/chat.py
@@ -1,0 +1,92 @@
+"""チャット機能のロジック集約（移設）。
+
+`app/chat_feature.py` から挙動を変更せず移設。
+"""
+
+from __future__ import annotations
+
+import time
+import gradio as gr
+from app.services.thread_service import ThreadService
+
+
+STATUS_GENERATING = "⌛ 回答生成中..."
+
+
+def llm_stream(_prompt):
+    for t in (
+        [
+            "了解です。 ",
+            "少しずつ返答をストリームします。",
+            "\n\n- 箇条書き\n- もOK\n\n`code` にも対応します。",
+        ]
+        + (["."] * 20)
+        + ["\n\n", "(回答完了)"]
+    ):
+        time.sleep(0.25)
+        yield t
+
+
+def guard_and_prep(message: str, history, thread_id: str = ""):
+    history = history or []
+    text = (message or "").strip()
+    if not text:
+        return (
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            gr.update(),
+            False,
+            "",
+        )
+    user_msg = {"role": "user", "content": text}
+    assistant_placeholder = {"role": "assistant", "content": "⌛ typing..."}
+    history = history + [user_msg, assistant_placeholder]
+    # persist user message if thread selected
+    if thread_id:
+        try:
+            ThreadService().add_user_message(thread_id, text)
+        except Exception:
+            pass
+    return (
+        history,
+        STATUS_GENERATING,
+        gr.update(visible=True, interactive=True),
+        gr.update(visible=False),
+        "",
+        True,
+        text,
+    )
+
+
+def stream_llm(go: bool, prompt: str, history, thread_id: str = ""):
+    if not go:
+        yield gr.update(), gr.update(), gr.update(), gr.update()
+        return
+    history = history or []
+    body = ""
+    for tok in llm_stream(prompt):
+        body += tok
+        if history and history[-1].get("role") == "assistant":
+            history[-1]["content"] = body
+        yield history, STATUS_GENERATING, gr.update(
+            visible=True, interactive=True
+        ), gr.update(visible=False)
+    # persist assistant final content
+    if thread_id and body:
+        try:
+            ThreadService().add_assistant_message(thread_id, body)
+        except Exception:
+            pass
+    yield history, "回答生成完了", gr.update(
+        visible=False, interactive=False
+    ), gr.update(visible=True)
+
+
+def stop_chat():
+    return (
+        gr.update(visible=False, interactive=False),
+        gr.update(visible=True),
+        "実行中の処理を停止しました。",
+    )

--- a/app/features/search.py
+++ b/app/features/search.py
@@ -1,0 +1,60 @@
+"""検索機能（ダミー）ロジックの集約（移設）。
+
+`app/search_feature.py` から挙動を変更せずに移設。
+"""
+
+from __future__ import annotations
+
+import gradio as gr
+
+
+def _search_users(query: str, top: int = 30) -> list[str]:
+    if not query:
+        return []
+    q = query.lower()
+    hits: list[str] = []
+    for i in range(1, 400):
+        mail = f"test{i}@test.com"
+        label = f"テスト{i}({mail})"
+        if q in label.lower() or q in mail.lower():
+            hits.append(label)
+        if len(hits) >= top:
+            break
+    return hits
+
+
+def chips_html(values):
+    vals = values or []
+    return (
+        "<div class='chips'>"
+        + "".join(f"<span class='chip'>{v}</span>" for v in vals)
+        + "</div>"
+    )
+
+
+def neutralize_email(s: str) -> str:
+    ZWSP = "\u200b"
+    return s.replace("@", f"{ZWSP}@{ZWSP}")
+
+
+def suggest(q, current_dropdown_value, selected_state):
+    q = (q or "").strip()
+    if len(q) < 2:
+        merged = sorted(set(selected_state or []))
+        return (
+            gr.update(choices=merged, value=current_dropdown_value),
+            "2文字以上で検索してください。",
+        )
+    hits = _search_users(q)
+    merged = sorted(set(hits) | set(selected_state or []))
+    hint = (
+        f"{len(hits)}件ヒット｜候補例: "
+        + ", ".join(neutralize_email(h) for h in hits[:3])
+        + (" …" if len(hits) > 3 else "")
+    )
+    return gr.update(choices=merged, value=current_dropdown_value), hint
+
+
+def on_change(new_value, _state):
+    vals = sorted(set(new_value or []))
+    return vals, chips_html(vals)


### PR DESCRIPTION
Step 4 の変更です。\n\n- add: app/features/chat.py, app/features/search.py\n- refactor: app/app_factory.py の import を差し替え\n\n受け入れ基準:\n- チャットの送受信/停止/ステータス復帰が現行同等\n- 設定タブの検索/選択/保存が現行同等\n\n問題なければマージお願いします（次は Step 5: UIヘッダー/アバター抽出）。