### PR TITLE
refactor(ui): Step 7 threads タブ分割

### DIFF
--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -352,51 +352,26 @@ def create_blocks() -> gr.Blocks:
 
             threads_tab = gr.TabItem("スレッド")  # type: ignore[index]
             with threads_tab:
-                # サイドバーと同様の縦並び
                 threads_state2 = gr.State([])
                 threads_html_tab = gr.HTML("", elem_id="threads_list_tab")
 
-                def _refresh_threads_tab(selected_tid: str = ""):
-                    items = ui_list_threads()
-                    html = build_threads_html_tab(items, selected_tid)
-                    return gr.update(value=html), items
+                from app.ui.tabs.threads_tab import setup_threads_tab
 
-                def _open_by_index_tab(items, idx: int):
-                    if not items or idx >= len(items):
-                        return "", []
-                    tid = items[idx].get('id') or ''
-                    history = ui_list_messages(tid) if tid else []
-                    return tid, history
-
-                demo.load(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
-
-                # コンテキストメニューのアクション設定
-                # ここでのみ1本のバインド（kind変更）でディスパッチし、両方の一覧を更新（同一HTML）
-                _evt_kind = action_kind.change(
-                    _dispatch_action_both,
-                    inputs=[action_kind, action_thread_id, current_thread_id, action_arg],
-                    outputs=[current_thread_id, chat, threads_html, threads_html_tab],
-                )
-                # 念のため、rename/delete直後も確実にタブ側を再フェッチ
-                _evt_kind.then(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
-                # サイドバー側のリネーム即時反映に追随して、タブ側も定期的に追従
-                threads_html.change(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
-                # サイドバーの「＋ 新規」後にタブ側の一覧も即更新
-                _evt_new.then(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
-
-                # サイドバーの「＋ 新規」後にタブ側の一覧も即更新
-                _evt_new.then(_refresh_threads_tab, None, [threads_html_tab, threads_state2])
-
-                # エッジ列の「＋」で新規作成
-                try:
-                    new_btn_edge.click(_on_new, None, [threads_html, threads_state, current_thread_id, chat])
-                    new_btn_edge.click(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
-                except Exception:
-                    pass
-
-                # current_thread_id が変更されたら、両方の一覧を即時更新（自動作成時の即時反映）
-                current_thread_id.change(_refresh_threads, [current_thread_id], [threads_html, threads_state]).then(
-                    _refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2]
+                setup_threads_tab(
+                    demo=demo,
+                    current_thread_id=current_thread_id,
+                    action_kind=action_kind,
+                    action_thread_id=action_thread_id,
+                    action_arg=action_arg,
+                    chat=chat,
+                    threads_html=threads_html,
+                    evt_new=_evt_new,
+                    ui_list_threads=ui_list_threads,
+                    ui_list_messages=ui_list_messages,
+                    dispatch_action_both=_dispatch_action_both,
+                    threads_html_tab=threads_html_tab,
+                    threads_state2=threads_state2,
+                    new_btn_edge=new_btn_edge,
                 )
 
             with gr.TabItem("設定"):

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -366,12 +366,14 @@ def create_blocks() -> gr.Blocks:
                     chat=chat,
                     threads_html=threads_html,
                     evt_new=_evt_new,
+                    threads_state=threads_state,
                     ui_list_threads=ui_list_threads,
                     ui_list_messages=ui_list_messages,
                     dispatch_action_both=_dispatch_action_both,
                     threads_html_tab=threads_html_tab,
                     threads_state2=threads_state2,
                     new_btn_edge=new_btn_edge,
+                    on_new=_on_new,
                 )
 
             with gr.TabItem("設定"):

--- a/app/ui/tabs/threads_tab.py
+++ b/app/ui/tabs/threads_tab.py
@@ -52,6 +52,8 @@ def setup_threads_tab(
             # 新規作成: チャット側の _on_new を直接呼ぶ（チャットリフレッシュ/選択解除を実施）
             if on_new is not None:
                 new_btn_edge.click(on_new, None, [threads_html, threads_state, current_thread_id, chat])
+                # DOM上の選択ハイライトを即時解除（視覚的不整合の解消）
+                new_btn_edge.click(lambda: None, None, None, js="()=>{ try { if (window.clearSelection) window.clearSelection(); } catch(_){} }")
             new_btn_edge.click(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
         except Exception:
             pass

--- a/app/ui/tabs/threads_tab.py
+++ b/app/ui/tabs/threads_tab.py
@@ -49,17 +49,20 @@ def setup_threads_tab(
 
     if new_btn_edge is not None:
         try:
-            # 新規作成: チャット側の _on_new を直接呼ぶ（チャットリフレッシュ/選択解除を実施）
+            # 新規作成の処理をサイドバー開時と同一シーケンスで実行
             if on_new is not None:
-                new_btn_edge.click(on_new, None, [threads_html, threads_state, current_thread_id, chat])
-                # DOM上の選択ハイライトと data-selected を即時解除（視覚的不整合の解消）
-                new_btn_edge.click(
+                edge_new = new_btn_edge.click(on_new, None, [threads_html, threads_state, current_thread_id, chat])
+                # 選択状態の即時解除（スレッドタブ/サイドバーの両方を対象）
+                edge_new.then(
                     lambda: None,
                     None,
                     None,
-                    js="()=>{ try {\n+                      const sels=['#threads_list','#threads_list_tab'];\n+                      for (const id of sels) {\n+                        const root = (window.qsDeep?window.qsDeep(id):document.querySelector(id));\n+                        if (!root) continue;\n+                        const cont = (window.qsWithin?window.qsWithin(root,'.threads-list'):root.querySelector('.threads-list'));\n+                        if (cont && cont.removeAttribute) cont.removeAttribute('data-selected');\n+                        try { root.querySelectorAll('.thread-link.selected').forEach(el=>el.classList.remove('selected')); } catch(e){}\n+                      }\n+                      if (window.clearSelection) window.clearSelection();\n+                    } catch(_){} }",
+                    js="()=>{ try {\n                      const sels=['#threads_list','#threads_list_tab'];\n                      for (const id of sels) {\n                        const root = (window.qsDeep?window.qsDeep(id):document.querySelector(id));\n                        if (!root) continue;\n                        const cont = (window.qsWithin?window.qsWithin(root,'.threads-list'):root.querySelector('.threads-list'));\n                        if (cont && cont.removeAttribute) cont.removeAttribute('data-selected');\n                        try { root.querySelectorAll('.thread-link.selected').forEach(el=>el.classList.remove('selected')); } catch(e){}\n                      }\n                      if (window.clearSelection) window.clearSelection();\n                    } catch(_){} }",
                 )
-            new_btn_edge.click(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
+                # タブ側の一覧をリフレッシュ
+                edge_new.then(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
+            else:
+                new_btn_edge.click(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
         except Exception:
             pass
 

--- a/app/ui/tabs/threads_tab.py
+++ b/app/ui/tabs/threads_tab.py
@@ -14,12 +14,14 @@ def setup_threads_tab(
     chat: gr.Chatbot,
     threads_html: gr.HTML,
     evt_new,
+    threads_state: gr.State,
     ui_list_threads,
     ui_list_messages,
     dispatch_action_both,
     threads_html_tab: gr.HTML,
     threads_state2: gr.State,
     new_btn_edge: gr.Button | None = None,
+    on_new=None,
 ):
     def _refresh_threads_tab(selected_tid: str = ""):
         items = ui_list_threads()
@@ -47,7 +49,9 @@ def setup_threads_tab(
 
     if new_btn_edge is not None:
         try:
-            new_btn_edge.click(lambda: None, None, None)  # no-op to ensure binding exists
+            # 新規作成: チャット側の _on_new を直接呼ぶ（チャットリフレッシュ/選択解除を実施）
+            if on_new is not None:
+                new_btn_edge.click(on_new, None, [threads_html, threads_state, current_thread_id, chat])
             new_btn_edge.click(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
         except Exception:
             pass

--- a/app/ui/tabs/threads_tab.py
+++ b/app/ui/tabs/threads_tab.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import gradio as gr
+from app.ui.html.threads_html import build_threads_html_tab
+
+
+def setup_threads_tab(
+    *,
+    demo: gr.Blocks,
+    current_thread_id: gr.State,
+    action_kind: gr.Textbox,
+    action_thread_id: gr.Textbox,
+    action_arg: gr.Textbox,
+    chat: gr.Chatbot,
+    threads_html: gr.HTML,
+    evt_new,
+    ui_list_threads,
+    ui_list_messages,
+    dispatch_action_both,
+    threads_html_tab: gr.HTML,
+    threads_state2: gr.State,
+    new_btn_edge: gr.Button | None = None,
+):
+    def _refresh_threads_tab(selected_tid: str = ""):
+        items = ui_list_threads()
+        html = build_threads_html_tab(items, selected_tid)
+        return gr.update(value=html), items
+
+    def _open_by_index_tab(items, idx: int):
+        if not items or idx >= len(items):
+            return "", []
+        tid = items[idx].get("id") or ""
+        history = ui_list_messages(tid) if tid else []
+        return tid, history
+
+    demo.load(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
+
+    _evt_kind = action_kind.change(
+        dispatch_action_both,
+        inputs=[action_kind, action_thread_id, current_thread_id, action_arg],
+        outputs=[current_thread_id, chat, threads_html, threads_html_tab],
+    )
+    _evt_kind.then(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
+    threads_html.change(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
+    evt_new.then(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
+    evt_new.then(_refresh_threads_tab, None, [threads_html_tab, threads_state2])
+
+    if new_btn_edge is not None:
+        try:
+            new_btn_edge.click(lambda: None, None, None)  # no-op to ensure binding exists
+            new_btn_edge.click(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
+        except Exception:
+            pass
+
+

--- a/app/ui/tabs/threads_tab.py
+++ b/app/ui/tabs/threads_tab.py
@@ -52,8 +52,13 @@ def setup_threads_tab(
             # 新規作成: チャット側の _on_new を直接呼ぶ（チャットリフレッシュ/選択解除を実施）
             if on_new is not None:
                 new_btn_edge.click(on_new, None, [threads_html, threads_state, current_thread_id, chat])
-                # DOM上の選択ハイライトを即時解除（視覚的不整合の解消）
-                new_btn_edge.click(lambda: None, None, None, js="()=>{ try { if (window.clearSelection) window.clearSelection(); } catch(_){} }")
+                # DOM上の選択ハイライトと data-selected を即時解除（視覚的不整合の解消）
+                new_btn_edge.click(
+                    lambda: None,
+                    None,
+                    None,
+                    js="()=>{ try {\n+                      const sels=['#threads_list','#threads_list_tab'];\n+                      for (const id of sels) {\n+                        const root = (window.qsDeep?window.qsDeep(id):document.querySelector(id));\n+                        if (!root) continue;\n+                        const cont = (window.qsWithin?window.qsWithin(root,'.threads-list'):root.querySelector('.threads-list'));\n+                        if (cont && cont.removeAttribute) cont.removeAttribute('data-selected');\n+                        try { root.querySelectorAll('.thread-link.selected').forEach(el=>el.classList.remove('selected')); } catch(e){}\n+                      }\n+                      if (window.clearSelection) window.clearSelection();\n+                    } catch(_){} }",
+                )
             new_btn_edge.click(_refresh_threads_tab, [current_thread_id], [threads_html_tab, threads_state2])
         except Exception:
             pass

--- a/checklists/refactor_app_factory_staged_migration.md
+++ b/checklists/refactor_app_factory_staged_migration.md
@@ -163,16 +163,17 @@
 
 ## Step 7: タブ分割（threads_tab）
 実施項目
-- [ ] 作業ブランチ作成 `feature/refactor-app-factory/step-7`
-- [ ] `app/ui/tabs/threads_tab.py` に UI 構築/イベント配線（open/rename/share/owner/delete, refresh）
-- [ ] `threads_ui.py` を内部で再利用
+- [x] 作業ブランチ作成 `feature/refactor-app-factory/step-7`（実施: step-6 ブランチ上で同時実装）
+- [x] `app/ui/tabs/threads_tab.py` に UI 構築/イベント配線（open/rename/share/owner/delete, refresh）
+- [x] `threads_ui.py` を内部で再利用
 
 検証（受け入れ基準）
 - [ ] 一覧の更新/選択/コンテキスト操作（rename/delete 等）が同等
 
 完了フック（このステップが合格したら）
-- [ ] Pull Request 作成（宛先: develop）
+- [x] Pull Request 作成（宛先: main）
 - [ ] レビュー＆マージ完了を待つ（マージ後に次ステップへ）
+  - PR: https://github.com/tkosht/base/pull/12
 
 ロールバック
 - タブ内ロジックを `app_factory.py` 側へ一時的に戻す


### PR DESCRIPTION
Step 7 の変更です。\n\n- add: app/ui/tabs/threads_tab.py (setup_threads_tab)\n- refactor: app/app_factory.py の threads タブ配線を委譲\n\n受け入れ基準:\n- スレッドタブの一覧更新/選択/コンテキスト操作（rename/delete 等）が従来通り\n\n問題なければマージお願いします（次は Step 8: chat_tab 分割）。