### PR TITLE
chore: update Codex settings

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,5 +1,5 @@
 projects = { "/home/devuser/workspace" = { trust_level = "trusted" } }
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_provider = "openai"
 approval_policy = "never"
 # sandbox_mode = "workspace-write"
@@ -38,3 +38,6 @@ model_reasoning_effort = "high"
 
 [sandbox_read_only]
 network_access = false
+
+[tui.model_availability_nux]
+"gpt-5.5" = 2

--- a/.codex/version.json
+++ b/.codex/version.json
@@ -1,1 +1,1 @@
-{"latest_version":"0.122.0","last_checked_at":"2026-04-22T09:38:13.857393291Z","dismissed_version":null}
+{"latest_version":"0.124.0","last_checked_at":"2026-04-24T01:18:32.469031622Z","dismissed_version":null}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,5 +17,7 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "terminal.integrated.ignoreBracketedPasteMode": true
+
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-code": "^2.1.87",
         "@google/gemini-cli": "^0.36.0",
-        "@openai/codex": "^0.122.0"
+        "@openai/codex": "^0.124.0"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
@@ -509,9 +509,9 @@
       ]
     },
     "node_modules/@openai/codex": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.122.0.tgz",
-      "integrity": "sha512-fMQoBo/D9S2/FNHgCMEGnEtG+LIm7ot2PbtpU26pyKDjKS47o9XByNv8gH3X0aDg6A4Algq21laUkFhonkgdsw==",
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0.tgz",
+      "integrity": "sha512-1EVAuPyAQZ8zIVMw3bPJ6a4R8ifLAZ7LGsOyknj5c2he9AFXVRCmWx12WrdZJ25wcBvOEKt1n1Zx+QAj0EVGbQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -521,19 +521,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.122.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.122.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.122.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.122.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.122.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.122.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.124.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.124.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.124.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.124.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.124.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.124.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.122.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.122.0-darwin-arm64.tgz",
-      "integrity": "sha512-J1rUDdVBgIwpFqwmkjgVWbbAk8oxuw/1JuIGUXJMz7wAsdvEgsVazwndIjQVN1nDtdD6zznlUtl69oPV1hhXcA==",
+      "version": "0.124.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-darwin-arm64.tgz",
+      "integrity": "sha512-lnuqeAdl+RjPWsqVZ8rrPskRIOZmzlyr8e5q/wFVEnMPsm9dWgjRW1PKa84UmDSQVOuz9GObF28DEHFyC4A8NA==",
       "cpu": [
         "arm64"
       ],
@@ -549,9 +549,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.122.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.122.0-darwin-x64.tgz",
-      "integrity": "sha512-VUXZxD/c/v2Mdler7epYJc8EH80fGbAC55QBVaxqSjX6OaoGO1sHqp7Nept1p52jMRtyc3VTv2/hkV1wEy+96w==",
+      "version": "0.124.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-darwin-x64.tgz",
+      "integrity": "sha512-Br+VlL83IOu96Urw+mkZ1PQXLsQXGAYEH6kXNt4ULuVt7qAdQY2FKYwIgLLVLl0vpMk8qWxdfdVMqhiu2uCHlg==",
       "cpu": [
         "x64"
       ],
@@ -567,9 +567,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.122.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.122.0-linux-arm64.tgz",
-      "integrity": "sha512-dtRm+R+BnwEZDFahIMl56tttzE3VtJLt2CuacKpn9ZDs8H9DW5lwGWdTEm94ANWWeyzigFObidQyitgdgwFHow==",
+      "version": "0.124.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-linux-arm64.tgz",
+      "integrity": "sha512-QXafFVQJxPfU1LSCI5afuHsF5evKAcbQpFuKou0Kl241/HG/zYHdwoWj546zH844gJgegIPAxPf36+RSkUsbbA==",
       "cpu": [
         "arm64"
       ],
@@ -585,9 +585,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.122.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.122.0-linux-x64.tgz",
-      "integrity": "sha512-GYQBkwER9RPn7spJOwB3f/pTyk3KWKsRI8W+2Dl5H3XSxJJ5aVZeNKBGChSw6lyJWAmuZXssBu037KQx15lsGA==",
+      "version": "0.124.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-linux-x64.tgz",
+      "integrity": "sha512-cJ4QfQIrz2gkXVWephiGo9JDyD3qLKhvkTTLk7gI8rKd7MZpVXn9/1e7pZCQnJVA7Dk6ocA5G+sxnR78SoIejw==",
       "cpu": [
         "x64"
       ],
@@ -603,9 +603,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.122.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.122.0-win32-arm64.tgz",
-      "integrity": "sha512-7SjzC/Xzw7md2//2W03Eid2bgY5LHfKinD6VwgfwLJbYFGsd9LDIduZC/8GABWSDXOgqE2SoZDiD2KwlG63Tkw==",
+      "version": "0.124.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-win32-arm64.tgz",
+      "integrity": "sha512-oDSI/CQh0kagBwWVPG9EiUBfHiY27ju3LPrjTVZg4VMpVJVNA31JTK8rHMZ6G/2gfNmOl6DMBA6+0ICxSkkshg==",
       "cpu": [
         "arm64"
       ],
@@ -621,9 +621,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.122.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.122.0-win32-x64.tgz",
-      "integrity": "sha512-0OR/QjqOZ7zX12s6Dh7qy/6H4WZRgFAp529EUg5C7tXj5xXdopi8A9InQfehu4KEJE3Qol2Lj/QBrOcahFXoPg==",
+      "version": "0.124.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-win32-x64.tgz",
+      "integrity": "sha512-t+lAwmCWwIWQKk6dKaYetRhQsmA+uDmQy1NLka1xAAv3PlNOH8iNz9Lsisr3qYkBR8Tf7tbQlt+pl9tw/A5mfA==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "devDependencies": {
     "@anthropic-ai/claude-code": "^2.1.87",
     "@google/gemini-cli": "^0.36.0",
-    "@openai/codex": "^0.122.0"
+    "@openai/codex": "^0.124.0"
   }
 }


### PR DESCRIPTION
## Context
- Keep repository-local Codex CLI, default model, and editor settings current.

## Changes
- Update @openai/codex from 0.122.0 to 0.124.0 in package manifests.
- Set local Codex default model to gpt-5.5 and record its TUI availability notice.
- Enable the Visual Studio Code integrated terminal bracketed paste ignore setting.

## Test
- uv run ruff check .
- uv run black --check .
