### PR TITLE
chore: update Codex CLI to 0.125.0

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -40,4 +40,4 @@ model_reasoning_effort = "high"
 network_access = false
 
 [tui.model_availability_nux]
-"gpt-5.5" = 2
+"gpt-5.5" = 4

--- a/.codex/version.json
+++ b/.codex/version.json
@@ -1,1 +1,1 @@
-{"latest_version":"0.124.0","last_checked_at":"2026-04-24T01:18:32.469031622Z","dismissed_version":null}
+{"latest_version":"0.125.0","last_checked_at":"2026-04-25T03:10:06.920266553Z","dismissed_version":null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-code": "^2.1.87",
         "@google/gemini-cli": "^0.36.0",
-        "@openai/codex": "^0.124.0"
+        "@openai/codex": "^0.125.0"
       }
     },
     "node_modules/@anthropic-ai/claude-code": {
@@ -509,9 +509,9 @@
       ]
     },
     "node_modules/@openai/codex": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0.tgz",
-      "integrity": "sha512-1EVAuPyAQZ8zIVMw3bPJ6a4R8ifLAZ7LGsOyknj5c2he9AFXVRCmWx12WrdZJ25wcBvOEKt1n1Zx+QAj0EVGbQ==",
+      "version": "0.125.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0.tgz",
+      "integrity": "sha512-GiE9wlgL95u/5BRirY5d3EaRLU1tu7Y1R09R8lCHHVmcQdSmhS809FdPDWH3gIYHS7ZriAPqXwJ3aLA0WKl40Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -521,19 +521,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.124.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.124.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.124.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.124.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.124.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.124.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.125.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.125.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.125.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.125.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.125.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.125.0-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.124.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-darwin-arm64.tgz",
-      "integrity": "sha512-lnuqeAdl+RjPWsqVZ8rrPskRIOZmzlyr8e5q/wFVEnMPsm9dWgjRW1PKa84UmDSQVOuz9GObF28DEHFyC4A8NA==",
+      "version": "0.125.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-darwin-arm64.tgz",
+      "integrity": "sha512-Gn2fHiSO0XgyHp1OSd5DWUTm66Bv9UEuipW5pVEj1E+hWZCOrdqnYttllKFWtRGj5yiKefNX3JIxONgh/ZwlOQ==",
       "cpu": [
         "arm64"
       ],
@@ -549,9 +549,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.124.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-darwin-x64.tgz",
-      "integrity": "sha512-Br+VlL83IOu96Urw+mkZ1PQXLsQXGAYEH6kXNt4ULuVt7qAdQY2FKYwIgLLVLl0vpMk8qWxdfdVMqhiu2uCHlg==",
+      "version": "0.125.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-darwin-x64.tgz",
+      "integrity": "sha512-TZ5Lek2X/UXTI9LXFxzarvQaJeuTrqVh4POc7soO/8RclVnCxADnCf15sivxLd5eiFW4t0myGoeVoM4lciRiRg==",
       "cpu": [
         "x64"
       ],
@@ -567,9 +567,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.124.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-linux-arm64.tgz",
-      "integrity": "sha512-QXafFVQJxPfU1LSCI5afuHsF5evKAcbQpFuKou0Kl241/HG/zYHdwoWj546zH844gJgegIPAxPf36+RSkUsbbA==",
+      "version": "0.125.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-linux-arm64.tgz",
+      "integrity": "sha512-pPnJoJD6rZ2Iin0zNt/up36bO2/EOp2B+1/rPHu/lSq3PJbT3Fmnfut2kJy5LylXb7bGA2XQbtqOogZzIbnlkA==",
       "cpu": [
         "arm64"
       ],
@@ -585,9 +585,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.124.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-linux-x64.tgz",
-      "integrity": "sha512-cJ4QfQIrz2gkXVWephiGo9JDyD3qLKhvkTTLk7gI8rKd7MZpVXn9/1e7pZCQnJVA7Dk6ocA5G+sxnR78SoIejw==",
+      "version": "0.125.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-linux-x64.tgz",
+      "integrity": "sha512-K2NTTEeBpz/G+N2x17UGWfauRt3So+ir4f+U/60l5PPnYEJB/w3YZrlXo2G9og8Dm9BqtoBAjoPV74sRv9tWWQ==",
       "cpu": [
         "x64"
       ],
@@ -603,9 +603,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.124.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-win32-arm64.tgz",
-      "integrity": "sha512-oDSI/CQh0kagBwWVPG9EiUBfHiY27ju3LPrjTVZg4VMpVJVNA31JTK8rHMZ6G/2gfNmOl6DMBA6+0ICxSkkshg==",
+      "version": "0.125.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-win32-arm64.tgz",
+      "integrity": "sha512-zxoUakw9oIHIFrAyk400XkkLBJFA6nOym0NDq6sQ/jhdcYraKqNSRCII2nsBwZHk+/4zgUvuk52iuutgysY/rQ==",
       "cpu": [
         "arm64"
       ],
@@ -621,9 +621,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.124.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.124.0-win32-x64.tgz",
-      "integrity": "sha512-t+lAwmCWwIWQKk6dKaYetRhQsmA+uDmQy1NLka1xAAv3PlNOH8iNz9Lsisr3qYkBR8Tf7tbQlt+pl9tw/A5mfA==",
+      "version": "0.125.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.125.0-win32-x64.tgz",
+      "integrity": "sha512-ofpOK+OWH5QFuUZ9pTM0d/PcXUXiIP5z5DpRcE9MlucJoyOl4Zy4Nu3NcuHF4YzCkZMQb6x3j0tjDEPHKqNQzw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "devDependencies": {
     "@anthropic-ai/claude-code": "^2.1.87",
     "@google/gemini-cli": "^0.36.0",
-    "@openai/codex": "^0.124.0"
+    "@openai/codex": "^0.125.0"
   }
 }


### PR DESCRIPTION
## Context
- Keep Codex CLI dependency and local Codex metadata current.

## Changes
- Bump @openai/codex and platform optional package lock entries to 0.125.0.
- Refresh .codex version metadata and GPT-5.5 availability NUX shown count.

## Test
- uv run ruff check .
- uv run black --check .
