### PR TITLE
docs: add harness self-review loop

### DIFF
--- a/.claude/skills/harness-autoptimizer/SKILL.md
+++ b/.claude/skills/harness-autoptimizer/SKILL.md
@@ -31,9 +31,10 @@ metadata:
 3. Constrain: `AutoptRequest` に editable paths、excluded paths、diff limits、validators、success criteria、draft pull request policy を固定する。
 4. Repair: Codex agent 自身が `AutoptRequest` の範囲内で最小変更する。
 5. Verify: `make doctor`、`make lint`、`make test` と diff guard を通す。
-6. Self-Audit: 実行経験を ExperienceCandidate として扱い、code simplification、test、validator、skill prompt、canonical rule、設計判断メモ、非追跡 state、discard のどれに値するか判断する。
-7. Reflect: low confidence、unsupported evidence、gate failure、保持価値不足の場合は修復や昇格をせず sanitized state に理由を残す。
-8. Propose: 成功時だけ draft pull request を作る。
+6. Review: Codex agent 自身が、要件・実装・prompt・test の整合性を code review と同じ厳しさで確認する。material finding があれば同じ `AutoptRequest` 制約内で Repair -> Verify -> Review を繰り返す。
+7. Self-Audit: 実行経験を ExperienceCandidate として扱い、code simplification、test、validator、skill prompt、canonical rule、設計判断メモ、非追跡 state、discard のどれに値するか判断する。
+8. Reflect: low confidence、unsupported evidence、gate failure、保持価値不足、または unresolved material finding がある場合は修復や昇格をせず sanitized state に理由を残す。
+9. Propose: 成功時だけ draft pull request を作る。
 
 ## Controller Prompts
 
@@ -57,3 +58,4 @@ uv run python .claude/skills/harness-autoptimizer/scripts/harness_autopt.py \
 - Markdown / settings / template / validation / test performance / skill resource は、それぞれの `mutable_paths`、`excluded_paths`、diff limit を守る。
 - raw prompt、raw model output、秘密情報、runtime logs、一回限りの作業メモは tracked knowledge に昇格しない。
 - 永続化する経験は、再発可能性、影響度、一般性、検証可能性、context cost を満たす蒸留済み artifact だけにする。
+- 自己レビューの反復は scope creep の許可ではない。同じ resource / goal / constraints 内で解消できない finding は停止理由として記録する。

--- a/.claude/skills/harness-autoptimizer/prompts/auto-controller.md
+++ b/.claude/skills/harness-autoptimizer/prompts/auto-controller.md
@@ -4,16 +4,17 @@ Codex agent is the controller. Python helpers are safety guards, state recorders
 
 Run this loop:
 
-Sense -> Classify -> Constrain -> Repair -> Verify -> Self-Audit -> Reflect -> Propose
+Sense -> Classify -> Constrain -> Repair -> Verify -> Review -> Self-Audit -> Reflect -> Propose
 
 1. Sense: read repo state, gate results, durations, failure text, changed paths, and the harness resource registry.
 2. Classify: compare the evidence against every registry resource. Select one resource and one registered goal only when confidence is high.
 3. Constrain: build an AutoptRequest with evidence, editable paths, excluded paths, protected prefixes, diff limits, validators, success criteria, and draft pull request policy.
 4. Repair: make the smallest useful change inside the AutoptRequest constraints.
 5. Verify: run the required validators and diff guard.
-6. Self-Audit: decide whether this run exposed a reusable harness lesson, code simplification, test, validator, canonical rule, or nothing durable.
-7. Reflect: if confidence is low, evidence is unsupported, verification fails, or the Self-Audit cannot justify a durable change, stop and record the reason.
-8. Propose: create a draft pull request only after verification passes.
+6. Review: perform a code-review pass against requirements, implementation, prompts, tests, helper boundaries, and the resource registry. If material findings remain and they can be fixed inside the same AutoptRequest constraints, repair them and repeat Verify -> Review.
+7. Self-Audit: decide whether this run exposed a reusable harness lesson, code simplification, test, validator, canonical rule, or nothing durable.
+8. Reflect: if confidence is low, evidence is unsupported, verification fails, a material finding remains unresolved, or the Self-Audit cannot justify a durable change, stop and record the reason.
+9. Propose: create a draft pull request only after verification passes and Review has no material findings.
 
 Rules:
 
@@ -24,5 +25,6 @@ Rules:
 - Do not read or modify `.env*`, `secrets/**`, local auth files, or runtime state.
 - Do not reduce test coverage or skip meaningful assertions to make gates pass.
 - Keep one run to one improvement.
+- Keep review-repair repetition bounded to the same resource, goal, editable_paths, excluded_paths, and diff limits; unresolved findings are stop reasons, not permission to expand scope.
 - Do not include raw prompts, raw model output, secrets, or runtime logs in pull request text.
 - Promote only distilled experience: rule, test, validator, design decision, or code simplification.

--- a/.claude/skills/harness-autoptimizer/prompts/repair-request.md
+++ b/.claude/skills/harness-autoptimizer/prompts/repair-request.md
@@ -12,6 +12,7 @@ Required behavior:
 - Stop if the evidence does not justify the selected resource and goal.
 - Stop if the change would require touching protected prefixes.
 - Create only a draft pull request after all validation passes.
+- After validation, run a self-review pass against the AutoptRequest, requirements, implementation, prompts, tests, helper boundaries, and resource registry. If material findings can be fixed inside the same constraints, repair them and rerun validation.
 - After verification, run the Self-Audit retention decision. Promote only distilled experience, never raw traces.
 
 The repair is successful only when every success criterion in the AutoptRequest is satisfied.

--- a/tests/harness_autoptimizer/test_harness_autopt.py
+++ b/tests/harness_autoptimizer/test_harness_autopt.py
@@ -209,7 +209,12 @@ def test_agent_controller_prompt_lists_all_resources() -> None:
     )
 
     assert "Codex agent is the controller" in prompt
-    assert "Sense -> Classify -> Constrain -> Repair -> Verify" in prompt
+    assert (
+        "Sense -> Classify -> Constrain -> Repair -> Verify -> Review"
+        in prompt
+    )
+    assert "requirements, implementation, prompts, tests" in prompt
+    assert "unresolved findings are stop reasons" in prompt
     assert "Self-Audit Contract" in prompt
     assert "Experience-to-Rule Contract" in prompt
     assert '"project-docs"' in prompt
@@ -234,6 +239,8 @@ def test_repair_prompt_includes_request_constraints_and_evidence() -> None:
     assert "README.md" in prompt
     assert "make doctor" in prompt
     assert "Do not edit outside editable_paths" in prompt
+    assert "self-review pass" in prompt
+    assert "helper boundaries" in prompt
 
 
 def test_parser_does_not_accept_manual_target_goal_controls() -> None:


### PR DESCRIPTION
## Context
- harness-autoptimizer should repeatedly review its own changes for requirement, implementation, prompt, and test consistency before proposing them.

## Changes
- Add a Review phase between Verify and Self-Audit in the harness-autoptimizer workflow.
- Bound review-repair repetition to the same AutoptRequest constraints and stop on unresolved material findings.
- Update prompt contract tests for the self-review loop.

## Test
- uv run ruff check .
- uv run black --check .
- uv run pytest -q tests/harness_autoptimizer/test_harness_autopt.py
- uv run pytest -q tests/test_template_contract.py
- make doctor
- make lint
- make test
