### PR TITLE
chore: feed back repo specialization harness improvements

### DIFF
--- a/.agents/skills/repo-template-specializer
+++ b/.agents/skills/repo-template-specializer
@@ -1,0 +1,1 @@
+../../.claude/skills/repo-template-specializer

--- a/.claude/skills/harness-autoptimizer/SKILL.md
+++ b/.claude/skills/harness-autoptimizer/SKILL.md
@@ -26,12 +26,12 @@ metadata:
 
 ## Workflow
 
-1. Sense: repo state、gate 結果、duration、failure text、changed paths、task friction、`docs/architecture/harness-resources.toml` を読む。
+1. Sense: repo state、gate 結果、duration、failure text、changed paths、task friction、明示された review artifact、`docs/architecture/harness-resources.toml` を読む。選択 target だけでなく、registry 全 resource paths に対して `ProactiveReviewProbe` による proactive review probe を走らせる。ただし各 resource の `excluded_paths` は尊重する。
 2. Classify: 全 registry resource を比較し、evidence から resource / goal / confidence / reason を決める。人間入力の `TARGET` / `GOAL` は使わない。
 3. Constrain: `AutoptRequest` に editable paths、excluded paths、diff limits、validators、success criteria、draft pull request policy を固定する。
 4. Repair: Codex agent 自身が `AutoptRequest` の範囲内で最小変更する。
 5. Verify: `make doctor`、`make lint`、`make test` と diff guard を通す。
-6. Review: Codex agent 自身が、要件・実装・prompt・test の整合性を code review と同じ厳しさで確認する。material finding があれば同じ `AutoptRequest` 制約内で Repair -> Verify -> Review を繰り返す。
+6. Review: Codex agent 自身が、要件・実装・prompt・test・proactive probe finding・review artifact の整合性を code review と同じ厳しさで確認する。finding は `ReviewFinding` として記録し、`verification_class` で検証種別を残す。target 外 resource の material finding は `out_of_scope` として記録し、黙殺しない。`excluded_paths` 内の歴史的記録や意図的な除外 path は false stop reason にしない。`ReviewReport` の `loop_count`、`converged`、`stop_reason` を確認し、material finding があれば同じ `AutoptRequest` 制約内で Repair -> Verify -> Review を繰り返す。
 7. Self-Audit: 実行経験を ExperienceCandidate として扱い、code simplification、test、validator、skill prompt、canonical rule、設計判断メモ、非追跡 state、discard のどれに値するか判断する。
 8. Reflect: low confidence、unsupported evidence、gate failure、保持価値不足、または unresolved material finding がある場合は修復や昇格をせず sanitized state に理由を残す。
 9. Propose: 成功時だけ draft pull request を作る。

--- a/.claude/skills/harness-autoptimizer/prompts/auto-controller.md
+++ b/.claude/skills/harness-autoptimizer/prompts/auto-controller.md
@@ -6,15 +6,15 @@ Run this loop:
 
 Sense -> Classify -> Constrain -> Repair -> Verify -> Review -> Self-Audit -> Reflect -> Propose
 
-1. Sense: read repo state, gate results, durations, failure text, changed paths, and the harness resource registry.
+1. Sense: read repo state, gate results, durations, failure text, changed paths, explicit review artifacts, and the harness resource registry. Also run a proactive review probe across all registry resource paths, not only the selected target resource, while respecting each resource's excluded_paths.
 2. Classify: compare the evidence against every registry resource. Select one resource and one registered goal only when confidence is high.
 3. Constrain: build an AutoptRequest with evidence, editable paths, excluded paths, protected prefixes, diff limits, validators, success criteria, and draft pull request policy.
 4. Repair: make the smallest useful change inside the AutoptRequest constraints.
 5. Verify: run the required validators and diff guard.
-6. Review: perform a code-review pass against requirements, implementation, prompts, tests, helper boundaries, and the resource registry. If material findings remain and they can be fixed inside the same AutoptRequest constraints, repair them and repeat Verify -> Review.
+6. Review: perform a code-review pass against requirements, implementation, prompts, tests, helper boundaries, proactive probe findings, explicit review artifacts, and the resource registry. Record each finding as a ReviewFinding with id, severity, material, status, verification_class, summary, and evidence. Use verification_class only; do not attach finding-specific commands. If material findings remain and they can be fixed inside the same AutoptRequest constraints, repair them and repeat Verify -> Review.
 7. Self-Audit: decide whether this run exposed a reusable harness lesson, code simplification, test, validator, canonical rule, or nothing durable.
 8. Reflect: if confidence is low, evidence is unsupported, verification fails, a material finding remains unresolved, or the Self-Audit cannot justify a durable change, stop and record the reason.
-9. Propose: create a draft pull request only after verification passes and Review has no material findings.
+9. Propose: create a draft pull request only after verification passes and the ReviewReport has converged.
 
 Rules:
 
@@ -26,5 +26,11 @@ Rules:
 - Do not reduce test coverage or skip meaningful assertions to make gates pass.
 - Keep one run to one improvement.
 - Keep review-repair repetition bounded to the same resource, goal, editable_paths, excluded_paths, and diff limits; unresolved findings are stop reasons, not permission to expand scope.
+- Do not let target focus hide adjacent problems. Findings from non-target resources must be recorded as out_of_scope material ReviewFinding records unless they are clearly non-material.
+- Do not probe inside excluded_paths; historical review artifacts and deliberately excluded paths must not become false stop reasons.
 - Do not include raw prompts, raw model output, secrets, or runtime logs in pull request text.
 - Promote only distilled experience: rule, test, validator, design decision, or code simplification.
+- Build a ReviewReport with loop_count, findings, convergence_conditions, converged, and stop_reason before proposing.
+- Treat material ReviewFinding records with status deferred, out_of_scope, or unresolved as non-converged stop reasons.
+- Resolve evidence through verification_class: validator, test, lint, diff_guard, or manual_review. Concrete validator commands come from AutoptRequest constraints.
+- Use ProactiveReviewProbe-style checks for known invariants that can be scanned across registry resource paths.

--- a/.claude/skills/harness-autoptimizer/prompts/repair-request.md
+++ b/.claude/skills/harness-autoptimizer/prompts/repair-request.md
@@ -5,6 +5,7 @@ Use the AutoptRequest as the binding instruction for this repair.
 Required behavior:
 
 - Treat classification as the Codex agent's evidence-based decision, not as a human override.
+- Review explicit review artifacts and run proactive probes across all registry resource paths before deciding the run has converged. Respect each resource's excluded_paths while probing.
 - Do not edit outside editable_paths.
 - Do not edit inside excluded_paths.
 - Respect max_changed_files and max_changed_lines.
@@ -12,7 +13,11 @@ Required behavior:
 - Stop if the evidence does not justify the selected resource and goal.
 - Stop if the change would require touching protected prefixes.
 - Create only a draft pull request after all validation passes.
-- After validation, run a self-review pass against the AutoptRequest, requirements, implementation, prompts, tests, helper boundaries, and resource registry. If material findings can be fixed inside the same constraints, repair them and rerun validation.
+- After validation, run a self-review pass against the AutoptRequest, requirements, implementation, prompts, tests, helper boundaries, proactive probe findings, explicit review artifacts, and resource registry. Record each item as a ReviewFinding with id, severity, material, status, verification_class, summary, and evidence. If material findings can be fixed inside the same constraints, repair them and rerun validation.
+- Build a ReviewReport with loop_count, findings, convergence_conditions, converged, and stop_reason before proposing. Use verification_class only; do not attach finding-specific commands. Concrete commands come from validators and diff guard.
+- Record non-target resource findings as out_of_scope material ReviewFinding records instead of silently ignoring them.
+- Do not probe inside excluded_paths; historical review artifacts and deliberately excluded paths must not become false stop reasons.
 - After verification, run the Self-Audit retention decision. Promote only distilled experience, never raw traces.
 
 The repair is successful only when every success criterion in the AutoptRequest is satisfied.
+It is not successful when the ReviewReport is not converged.

--- a/.claude/skills/harness-autoptimizer/scripts/harness_autopt.py
+++ b/.claude/skills/harness-autoptimizer/scripts/harness_autopt.py
@@ -64,6 +64,31 @@ HIGH_SIGNAL_TERMS = {
     "--target",
     "--goal",
 }
+REVIEW_SEVERITIES = {"high", "medium", "low"}
+REVIEW_STATUSES = {
+    "fixed",
+    "not_applicable",
+    "deferred",
+    "out_of_scope",
+    "unresolved",
+}
+REVIEW_VERIFICATION_CLASSES = {
+    "validator",
+    "test",
+    "lint",
+    "diff_guard",
+    "manual_review",
+}
+RAW_TRACE_MARKERS = (
+    "raw_prompt",
+    "raw prompt",
+    "raw_output",
+    "raw output",
+    "model_output",
+    "model output",
+    "stdout",
+    "stderr",
+)
 
 
 @dataclass(frozen=True)
@@ -181,6 +206,58 @@ class ExperienceAssessment:
     reason: str
 
 
+@dataclass(frozen=True)
+class ReviewFinding:
+    id: str
+    severity: str
+    material: bool
+    status: str
+    verification_class: str
+    summary: str
+    evidence: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.severity not in REVIEW_SEVERITIES:
+            raise ValueError(f"unknown review severity: {self.severity}")
+        if self.status not in REVIEW_STATUSES:
+            raise ValueError(f"unknown review finding status: {self.status}")
+        if self.verification_class not in REVIEW_VERIFICATION_CLASSES:
+            raise ValueError(
+                "unknown review verification_class: " + self.verification_class
+            )
+
+
+@dataclass(frozen=True)
+class ProactiveReviewProbe:
+    id: str
+    summary: str
+    needles: tuple[str, ...]
+    resource_ids: tuple[str, ...] = ()
+    severity: str = "medium"
+    material: bool = True
+    verification_class: str = "manual_review"
+
+    def __post_init__(self) -> None:
+        if self.severity not in REVIEW_SEVERITIES:
+            raise ValueError(
+                f"unknown proactive probe severity: {self.severity}"
+            )
+        if self.verification_class not in REVIEW_VERIFICATION_CLASSES:
+            raise ValueError(
+                "unknown proactive probe verification_class: "
+                + self.verification_class
+            )
+
+
+@dataclass(frozen=True)
+class ReviewReport:
+    loop_count: int
+    findings: tuple[ReviewFinding, ...]
+    convergence_conditions: tuple[str, ...]
+    converged: bool
+    stop_reason: str
+
+
 @dataclass
 class AutoptState:
     run_id: str
@@ -221,6 +298,15 @@ def sanitize_state_payload(payload: dict[str, Any]) -> dict[str, Any]:
             continue
         clean[key] = value
     return clean
+
+
+def sanitize_review_text(value: str) -> str:
+    """Omit raw trace text from persisted review reports."""
+
+    lowered = value.casefold()
+    if any(marker in lowered for marker in RAW_TRACE_MARKERS):
+        return "[omitted raw trace]"
+    return value
 
 
 def _experience_text(candidate: ExperienceCandidate) -> str:
@@ -640,6 +726,92 @@ def is_request_actionable(
     return request.classification.confidence >= min_confidence
 
 
+def iter_resource_probe_files(
+    root: Path,
+    rel: str,
+    *,
+    excluded_prefixes: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    clean = normalize_rel_path(rel)
+    if is_protected_path(clean) or is_path_excluded(clean, excluded_prefixes):
+        return ()
+
+    path = root / clean
+    if path.is_file():
+        return (clean,)
+    if not path.is_dir():
+        return ()
+
+    files: list[str] = []
+    for child in sorted(path.rglob("*")):
+        if not child.is_file():
+            continue
+        rel_child = child.relative_to(root).as_posix()
+        if is_protected_path(rel_child) or is_path_excluded(
+            rel_child, excluded_prefixes
+        ):
+            continue
+        files.append(rel_child)
+    return tuple(files)
+
+
+def run_proactive_review_probes(
+    root: Path,
+    resources: dict[str, HarnessResource],
+    probes: tuple[ProactiveReviewProbe, ...],
+    *,
+    target_resource_id: str,
+) -> tuple[ReviewFinding, ...]:
+    """Scan registry resource paths for material issues beyond the target."""
+
+    findings: list[ReviewFinding] = []
+    for probe in probes:
+        resource_ids = probe.resource_ids or tuple(sorted(resources))
+        for resource_id in resource_ids:
+            resource = resources.get(resource_id)
+            if resource is None:
+                continue
+            for rel in resource.paths:
+                for file_rel in iter_resource_probe_files(
+                    root,
+                    rel,
+                    excluded_prefixes=resource.excluded_paths,
+                ):
+                    try:
+                        text = (root / file_rel).read_text(encoding="utf-8")
+                    except UnicodeDecodeError:
+                        continue
+                    for needle in probe.needles:
+                        if needle not in text:
+                            continue
+                        status = (
+                            "unresolved"
+                            if resource_id == target_resource_id
+                            else "out_of_scope"
+                        )
+                        finding_id = (
+                            f"{probe.id}:{resource_id}:{file_rel}"
+                        ).replace("/", "-")
+                        findings.append(
+                            ReviewFinding(
+                                id=finding_id,
+                                severity=probe.severity,
+                                material=probe.material,
+                                status=status,
+                                verification_class=probe.verification_class,
+                                summary=(
+                                    f"{probe.summary}: {needle} in {file_rel}"
+                                ),
+                                evidence=(
+                                    f"resource={resource_id}",
+                                    f"path={file_rel}",
+                                    f"needle={needle}",
+                                ),
+                            )
+                        )
+    return tuple(findings)
+
+
 def autopt_request_to_dict(request: AutoptRequest) -> dict[str, Any]:
     return asdict(request)
 
@@ -736,8 +908,121 @@ def write_autopt_request(
     return request_path
 
 
+def _has_unresolved_material_finding(
+    findings: tuple[ReviewFinding, ...],
+) -> bool:
+    unresolved_statuses = {"deferred", "out_of_scope", "unresolved"}
+    return any(
+        finding.material and finding.status in unresolved_statuses
+        for finding in findings
+    )
+
+
+def build_review_report(
+    *,
+    findings: tuple[ReviewFinding, ...],
+    loop_count: int,
+    gate_passed: bool,
+    diff_guard: DiffGuardResult,
+    self_audit_completed: bool,
+) -> ReviewReport:
+    if loop_count < 1:
+        raise ValueError("loop_count must be at least 1")
+
+    material_resolved = not _has_unresolved_material_finding(findings)
+    converged = (
+        gate_passed
+        and diff_guard.ok
+        and self_audit_completed
+        and material_resolved
+    )
+
+    convergence_conditions = (
+        "validators pass" if gate_passed else "validators failed",
+        "diff guard pass" if diff_guard.ok else "diff guard failed",
+        (
+            "material findings resolved"
+            if material_resolved
+            else "material findings unresolved"
+        ),
+        (
+            "self-audit completed"
+            if self_audit_completed
+            else "self-audit incomplete"
+        ),
+        "raw traces omitted",
+    )
+    stop_reasons = tuple(
+        condition
+        for condition in convergence_conditions
+        if condition.endswith("failed")
+        or condition.endswith("unresolved")
+        or condition.endswith("incomplete")
+    )
+    return ReviewReport(
+        loop_count=loop_count,
+        findings=findings,
+        convergence_conditions=convergence_conditions,
+        converged=converged,
+        stop_reason="; ".join(stop_reasons) if stop_reasons else "converged",
+    )
+
+
+def is_review_converged(report: ReviewReport) -> bool:
+    return report.converged
+
+
+def review_report_to_dict(report: ReviewReport) -> dict[str, Any]:
+    return {
+        "loop_count": report.loop_count,
+        "findings": [
+            {
+                "id": finding.id,
+                "severity": finding.severity,
+                "material": finding.material,
+                "status": finding.status,
+                "verification_class": finding.verification_class,
+                "summary": sanitize_review_text(finding.summary),
+                "evidence": [
+                    sanitize_review_text(item) for item in finding.evidence
+                ],
+            }
+            for finding in report.findings
+        ],
+        "convergence_conditions": list(report.convergence_conditions),
+        "converged": report.converged,
+        "stop_reason": sanitize_review_text(report.stop_reason),
+    }
+
+
+def write_review_report(
+    log_root: Path, run_id: str, report: ReviewReport
+) -> Path:
+    path = log_root / datetime.now(UTC).strftime("%Y/%m/%d") / run_id
+    path.mkdir(parents=True, exist_ok=True)
+    review_path = path / "review.json"
+    review_path.write_text(
+        json.dumps(
+            review_report_to_dict(report),
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return review_path
+
+
 def build_pr_title(resource: HarnessResource, goal: str) -> str:
     return f"[harness-autopt] improve {resource.id} {goal}"
+
+
+def summarize_review_findings(
+    findings: tuple[ReviewFinding, ...],
+) -> dict[str, int]:
+    counts = {status: 0 for status in sorted(REVIEW_STATUSES)}
+    for finding in findings:
+        counts[finding.status] += 1
+    return {status: count for status, count in counts.items() if count}
 
 
 def build_pr_body(
@@ -746,6 +1031,7 @@ def build_pr_body(
     resource: HarnessResource,
     diff_guard: DiffGuardResult,
     gate_commands: tuple[str, ...],
+    review_report: ReviewReport | None = None,
 ) -> str:
     files = (
         "\n".join(f"- `{path}`" for path in diff_guard.changed_files)
@@ -756,6 +1042,22 @@ def build_pr_body(
         f"Codex-controlled harness optimization run `{state.run_id}` improved "
         f"`{resource.id}` for `{state.goal}`."
     )
+    review_section = ""
+    if review_report is not None:
+        counts = summarize_review_findings(review_report.findings)
+        finding_summary = (
+            ", ".join(f"{status}: {count}" for status, count in counts.items())
+            or "none"
+        )
+        stop_reason = sanitize_review_text(review_report.stop_reason)
+        review_section = f"""
+## Review Loop
+
+- loop count: {review_report.loop_count}
+- converged: {str(review_report.converged).lower()}
+- finding status: {finding_summary}
+- stop reason: {stop_reason}
+"""
     return f"""## Summary
 
 {summary}
@@ -779,6 +1081,7 @@ def build_pr_body(
 - changed files: {len(diff_guard.changed_files)}
 - changed lines: {diff_guard.changed_lines}
 - violations: none
+{review_section}
 
 Raw prompts, raw model outputs, and local runtime logs are intentionally omitted.
 """
@@ -884,15 +1187,23 @@ def create_pull_request(
     resource: HarnessResource,
     diff_guard: DiffGuardResult,
     base: str,
+    review_report: ReviewReport,
     *,
     draft: bool = False,
 ) -> str:
+    if not is_review_converged(review_report):
+        raise RuntimeError(
+            "ReviewReport must be converged before creating a pull request: "
+            + sanitize_review_text(review_report.stop_reason)
+        )
+
     title = build_pr_title(resource, state.goal)
     body = build_pr_body(
         state=state,
         resource=resource,
         diff_guard=diff_guard,
         gate_commands=resource.validators,
+        review_report=review_report,
     )
     runner.run(["git", "add", "-A"], worktree, check=True)
     runner.run(

--- a/.claude/skills/repo-template-specializer/SKILL.md
+++ b/.claude/skills/repo-template-specializer/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: repo-template-specializer
+description: "Use when a repository copied from a template or base repository must be slimmed down and specialized for its own project, including README/docs/settings/agent instructions, retained harness selection, validation hardening, and review-loop closure."
+---
+
+# Repo Template Specializer
+
+## Purpose
+
+Template/base 複製 repo を、配布元ではなく現 repo の固有目的・検証契約・AI 運用面へ収束させる。テンプレート配布用の導線を削り、残す shared harness は現 repo の目的で再定義する。
+
+## Workflow
+
+1. Sense: `references/checklist.md` を読み、README、docs、metadata、CI、settings、agent instructions、skills、scripts、tests、review artifact から template/base 残骸を拾う。明示された review artifact がある場合は、先に finding を構造化する。
+2. Inventory: 見つけた項目を identity surface、template-only asset、retained shared harness、validation/review surface に分ける。歴史的記録、外部由来、意図的な除外 path は false positive 候補として分離する。
+3. Specialize: active な説明・設定・AI 向け instruction を現 repo の目的、所有者、検証コマンド、運用ルールへ置き換える。instruction surface が大きい場合は `repo-instruction-optimizer` を併用する。
+4. Remove: 現 repo が template 配布をしない場合だけ、starter、overlay、sample、template smoke test などの配布側資産を削除する。削除前後で active reference を必ず更新する。
+5. Retain and harden: 残す harness は配布元名ではなく用途名へ再定義し、manifest、registry、Makefile、tests、skills、docs を同期する。人間または AI review で見つかった漏れは validator/test に落とす。
+6. Review loop: task-specific scan と `harness-autoptimizer` の review loop を回し、loop count、material finding、out-of-scope finding、converged、stop reason を `ReviewReport` 相当で確認する。
+7. Verify and hand off: `make doctor`、`make lint`、`make test` と focused checks を通す。PR 作成は収束後に `git-commit-pr` へ委譲する。
+
+## References
+
+- `references/checklist.md`
+
+## Guardrails
+
+- Template 由来でも現 repo が使う資産は削除せず、retained harness として再定義する。
+- 歴史的な decision record や review 記録は active instruction と混同しない。
+- 汎用 Skill なので、特定 repo 固有の名称は例示に留め、手順の前提にしない。
+- v1 では新規 helper script を増やさない。繰り返し発生する機械検出だけを後続で script 化する。

--- a/.claude/skills/repo-template-specializer/references/checklist.md
+++ b/.claude/skills/repo-template-specializer/references/checklist.md
@@ -1,0 +1,53 @@
+# Repo Template Specializer Checklist
+
+この checklist は、template/base から複製した repo を固有 repo にする時の漏れ検出に使う。項目は機械検索だけで終わらせず、active な導線か、歴史的記録か、意図的な retained harness かを分類する。
+
+## Inputs
+
+- User request、review artifact、open findings。
+- README、package metadata、Makefile、CI、Issue/PR template、CODEOWNERS、security/contributing/design docs。
+- `AGENTS.md`、`CLAUDE.md`、`GEMINI.md`、`.cursor/`、`.codex/config.toml`、`docs/ai/`。
+- `docs/architecture/*`、harness manifest、resource registry、decision records。
+- `.claude/skills/*`、`.agents/skills/*`、`.codex/skills/*`、`docs/ai/skills/*`。
+- `bin/`、repo-local scripts、tests、fixtures、sample assets。
+
+## Residue Probes
+
+- Old repo or template identity: base repo name、template、starter、scaffold、overlay、generated repo、shared settings などの active wording。
+- Deleted or template-only paths: starter helpers、template scripts、overlay scripts、sample templates、template smoke tests、old design samples。
+- Hardcoded upstream ownership: `OWNER`、`REPO`、remote URL、GitHub API helper、workflow dispatch target。
+- Stale retained harness names: old harness filenames、test names、registry IDs、Makefile targets、skill examples。
+- Agent-facing stale references: skill prompts、source maps、compatibility adapters、settings comments、review examples。
+- Review-loop gaps: command success onlyで終わり、material finding、out-of-scope finding、loop count、stop reason が記録されていない状態。
+
+## Action Matrix
+
+- Active identity surface: 現 repo の目的、利用者、検証、運用へ置換する。
+- Template-only asset: 現 repo が template 配布をしないなら削除し、参照を全て更新する。
+- Retained shared harness: 削除せず、用途名へ rename/reframe し、manifest、registry、tests、docs、skills を同期する。
+- Historical record: 原則保持し、active residue scan の false stop reason にならないよう除外や文脈を明確にする。
+- External provenance: 必要なら残すが、現 repo の instruction や command として読まれない場所に置く。
+
+## Validation Hardening
+
+- 人間または AI review で出た漏れごとに、validator または test のどちらで再発検知するかを決める。
+- 削除済み path 参照、old helper 名、old repo name、hardcoded upstream repo、old harness 名は negative test を追加する。
+- `.claude/skills/*/SKILL.md` と `docs/ai/skills/*` も active reference scan の対象に含める。
+- Skill を追加・削除した時は `.claude/skills`、`.agents/skills`、`.codex/skills`、`docs/ai/skills`、retained harness manifest の同期を確認する。
+- すべてを script 化しない。語義判断が必要な項目は checklist と review loop、再発性が高い項目は validator/test に分ける。
+
+## Review Loop Acceptance
+
+- 少なくとも 1 回は task-specific scan と code-review 観点の自己レビューを行う。
+- material finding がある間は同じ scope 内で Repair -> Verify -> Review を繰り返す。
+- target 外の material finding は `out_of_scope` として記録し、黙殺しない。
+- `ReviewReport` 相当の loop count、converged、stop reason が説明できるまで PR 作成に進まない。
+- 最終状態で active な docs/config/scripts/tests/skills が現 repo の identity と一致し、削除済み path 参照が残っていない。
+
+## Final Checks
+
+- `make doctor`
+- `make lint`
+- `make test`
+- Focused structural checks for new or changed skills and symlinks。
+- Review artifact がある場合は、全 finding が resolved、out-of-scope、または intentional false positive のどれかに分類されていること。

--- a/.codex/skills/repo-template-specializer
+++ b/.codex/skills/repo-template-specializer
@@ -1,0 +1,1 @@
+../../.agents/skills/repo-template-specializer

--- a/bin/github_api_pr.sh
+++ b/bin/github_api_pr.sh
@@ -1,26 +1,44 @@
-#!/usr/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-. ./.env
+if [[ -f ./.env ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env
+  set +a
+fi
 
-OWNER=tkosht
-REPO=base
-N=10
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+
+remote_url="${GITHUB_REMOTE_URL:-$(git config --get remote.origin.url)}"
+repo_slug="${GITHUB_REPOSITORY:-}"
+
+if [[ -z "$repo_slug" ]]; then
+  if [[ "$remote_url" =~ github.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    repo_slug="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  else
+    echo "Could not resolve GitHub owner/repo from remote.origin.url" >&2
+    exit 1
+  fi
+fi
+
+pr_limit="${PR_LIMIT:-10}"
 
 pr_url_list=$(
-curl -sSL \
-  -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer $GITHUB_TOKEN" \
-  -H "X-GitHub-Api-Version: 2022-11-28" \
-  "https://api.github.com/repos/$OWNER/$REPO/pulls?state=all&per_page=$N" \
-  | jq -r '.[].url'
+  curl -sSL \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/$repo_slug/pulls?state=all&per_page=$pr_limit" \
+    | jq -r '.[].url'
 )
 
 for url in $pr_url_list
 do
-    curl -sSL \
-      -H "Accept: application/vnd.github+json" \
-      -H "Authorization: Bearer $GITHUB_TOKEN" \
-      -H "X-GitHub-Api-Version: 2022-11-28" \
-      $url
-    break
+  curl -sSL \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GITHUB_TOKEN" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "$url"
+  break
 done

--- a/docs/ai/skills/README.md
+++ b/docs/ai/skills/README.md
@@ -16,4 +16,5 @@
 - `grill-me-essential-first`
 - `harness-autoptimizer`
 - `repo-instruction-optimizer`
+- `repo-template-specializer`
 - `skill-authoring`

--- a/docs/ai/skills/harness-autoptimizer.md
+++ b/docs/ai/skills/harness-autoptimizer.md
@@ -4,6 +4,6 @@
 - Use when: slow / failing gates、Codex agent control loop、Codex experience capture、harness resource registry、Markdown docs / settings / validation surface の自己最適化設計や実行
 - Codex entrypoint: `.agents/skills/harness-autoptimizer`
 - Claude entrypoint: `.claude/skills/harness-autoptimizer`
-- Key outputs: AutoptRequest、ExperienceCandidate、ExperienceAssessment、sanitized run state、diff guard result、gate results、draft pull request URL
+- Key outputs: AutoptRequest、ProactiveReviewProbe、ReviewFinding、ReviewReport、ExperienceCandidate、ExperienceAssessment、sanitized run state、diff guard result、gate results、draft pull request URL
 - Notes: 自律判断の主体は Codex agent。Python helper は prompt assembly、sanitized state、diff guard、検証実行、draft pull request 補助に限定する
 - Prompt entrypoints: `.claude/skills/harness-autoptimizer/prompts/auto-controller.md`、`.claude/skills/harness-autoptimizer/prompts/self-audit.md`、`.claude/skills/harness-autoptimizer/prompts/experience-to-rule.md`、`.claude/skills/harness-autoptimizer/prompts/repair-request.md`

--- a/docs/ai/skills/repo-template-specializer.md
+++ b/docs/ai/skills/repo-template-specializer.md
@@ -1,0 +1,7 @@
+# repo-template-specializer
+
+- Purpose: template/base 複製 repo を、現 repo 固有の identity、検証契約、AI 運用面へスリム化・特化する
+- Use when: README/docs/settings/agent instructions などに template/base 由来の記述や導線が残っている repo を整理する
+- Codex entrypoint: `.agents/skills/repo-template-specializer`
+- Claude entrypoint: `.claude/skills/repo-template-specializer`
+- Key outputs: residue inventory、removal/retention decision、validator/test hardening、ReviewReport 相当の収束確認

--- a/docs/architecture/base-harness-set.md
+++ b/docs/architecture/base-harness-set.md
@@ -34,6 +34,7 @@
   - `grill-me-essential-first`
   - `harness-autoptimizer`
   - `repo-instruction-optimizer`
+  - `repo-template-specializer`
   - `skill-authoring`
 - ハーネス資源 registry
   - `docs/architecture/harness-resources.toml`
@@ -50,6 +51,7 @@
   - `.claude/skills/harness-autoptimizer/prompts/*`
   - `scripts/ci/repo_copy.py`
   - `tests/codex_subagent/*`
+  - `tests/harness_autoptimizer/*`
   - `tests/test_base_harness_set.py`
   - `tests/test_template_contract.py`
 - ops scaffold

--- a/docs/architecture/base-harness-set.toml
+++ b/docs/architecture/base-harness-set.toml
@@ -1,5 +1,5 @@
 title = "base harness set"
-version = 2
+version = 3
 
 skills = [
   "ai-agent-collaboration-exec",
@@ -10,6 +10,7 @@ skills = [
   "grill-me-essential-first",
   "harness-autoptimizer",
   "repo-instruction-optimizer",
+  "repo-template-specializer",
   "skill-authoring",
 ]
 
@@ -67,6 +68,7 @@ included_paths = [
   ".claude/skills/harness-autoptimizer/prompts/repair-request.md",
   "docs/ai/skills/grill-me.md",
   "docs/ai/skills/grill-me-essential-first.md",
+  "docs/ai/skills/repo-template-specializer.md",
   "docs/design/README.md",
   "docs/design/samples/starter-b2b-corporate/DESIGN.sample.md",
   "docs/design/samples/starter-b2b-corporate/preview.html",
@@ -87,6 +89,7 @@ included_paths = [
   "scripts/template/sync_upstream_skill.py",
   "scripts/template/upstream_skills.toml",
   "tests/codex_subagent",
+  "tests/harness_autoptimizer",
   "tests/test_base_harness_set.py",
   "tests/test_template_contract.py",
 ]

--- a/docs/architecture/harness-resources.toml
+++ b/docs/architecture/harness-resources.toml
@@ -1,5 +1,5 @@
 title = "harness resource registry"
-version = 1
+version = 2
 
 [[resources]]
 id = "codex-subagent"
@@ -60,6 +60,37 @@ validators = [
 mutation_policy = "autonomous_pr"
 risk_level = "high"
 goals = ["stability", "self-audit"]
+
+[[resources]]
+id = "repo-template-specializer"
+kind = "skill"
+authority = "canonical"
+paths = [
+  ".claude/skills/repo-template-specializer",
+  ".agents/skills/repo-template-specializer",
+  ".codex/skills/repo-template-specializer",
+  "docs/ai/skills/repo-template-specializer.md",
+]
+mutable_paths = [
+  ".claude/skills/repo-template-specializer",
+  "docs/ai/skills/repo-template-specializer.md",
+]
+depends_on = [
+  "harness-autoptimizer",
+  "repo-instruction-optimizer",
+  "template-surface",
+  "validation-surface",
+]
+validators = [
+  "make doctor",
+  "make lint",
+  "make test",
+]
+mutation_policy = "guarded_pr"
+risk_level = "medium"
+goals = ["consistency", "specialization", "review-quality"]
+max_changed_files = 4
+max_changed_lines = 450
 
 [[resources]]
 id = "instruction-surface"

--- a/scripts/ci/validate_template.py
+++ b/scripts/ci/validate_template.py
@@ -21,6 +21,7 @@ RETAINED_SKILLS = [
     "grill-me-essential-first",
     "harness-autoptimizer",
     "repo-instruction-optimizer",
+    "repo-template-specializer",
     "skill-authoring",
 ]
 REQUIRED_PATHS = [
@@ -58,6 +59,7 @@ REQUIRED_PATHS = [
     "docs/ai/skills/grill-me.md",
     "docs/ai/skills/grill-me-essential-first.md",
     "docs/ai/skills/harness-autoptimizer.md",
+    "docs/ai/skills/repo-template-specializer.md",
     ".claude/skills/harness-autoptimizer/prompts/auto-controller.md",
     ".claude/skills/harness-autoptimizer/prompts/self-audit.md",
     ".claude/skills/harness-autoptimizer/prompts/experience-to-rule.md",
@@ -86,6 +88,7 @@ REQUIRED_PATHS = [
     "scripts/template/sync_upstream_skill.py",
     "scripts/template/upstream_skills.toml",
     "templates/manifest.yaml",
+    "bin/github_api_pr.sh",
     "secrets/README.md",
 ]
 FORBIDDEN_PATHS = [
@@ -219,6 +222,7 @@ REQUIRED_HARNESS_RESOURCE_IDS = {
     "instruction-surface",
     "knowledge-docs",
     "project-docs",
+    "repo-template-specializer",
     "test-performance",
 }
 PROJECT_DOCS_RESOURCE_PATHS = {
@@ -386,6 +390,14 @@ def _check_harness_autoptimizer_contract(
         "Verify",
         "Self-Audit",
         "AutoptRequest",
+        "ReviewFinding",
+        "ReviewReport",
+        "ProactiveReviewProbe",
+        "proactive review probe",
+        "out_of_scope",
+        "verification_class",
+        "loop_count",
+        "converged",
         "ExperienceCandidate",
     ):
         if needle not in skill_text:
@@ -393,6 +405,28 @@ def _check_harness_autoptimizer_contract(
                 ".claude/skills/harness-autoptimizer/SKILL.md "
                 f"missing controller contract: {needle}"
             )
+
+    for rel in (
+        ".claude/skills/harness-autoptimizer/prompts/auto-controller.md",
+        ".claude/skills/harness-autoptimizer/prompts/repair-request.md",
+    ):
+        path = root / rel
+        if not path.exists():
+            continue
+        prompt_text = path.read_text(encoding="utf-8")
+        for needle in (
+            "ReviewFinding",
+            "ReviewReport",
+            "proactive",
+            "out_of_scope",
+            "verification_class",
+            "loop_count",
+            "converged",
+        ):
+            if needle not in prompt_text:
+                errors.append(
+                    f"{rel} missing structured review contract: {needle}"
+                )
 
     helper_text = (
         root
@@ -402,6 +436,24 @@ def _check_harness_autoptimizer_contract(
         / "scripts"
         / "harness_autopt.py"
     ).read_text(encoding="utf-8")
+    for needle in (
+        "class ReviewFinding",
+        "class ProactiveReviewProbe",
+        "class ReviewReport",
+        "def build_review_report",
+        "def run_proactive_review_probes",
+        "def write_review_report",
+        "ReviewReport must be converged before creating a pull request",
+        "review_report=review_report",
+        "verification_class",
+        "loop_count",
+        "converged",
+    ):
+        if needle not in helper_text:
+            errors.append(
+                "harness_autopt.py missing structured review helper: " + needle
+            )
+
     forbidden_helpers = (
         "def run_candidate_generation",
         "def run_autoptimization",
@@ -437,6 +489,29 @@ def _check_harness_autoptimizer_contract(
         errors.append(
             "harness-autopt workflow must start a Codex agent controller"
         )
+
+
+def _check_github_api_helper(root: Path, errors: list[str]) -> None:
+    helper = root / "bin" / "github_api_pr.sh"
+    if not helper.exists():
+        return
+    text = helper.read_text(encoding="utf-8")
+    for forbidden in (
+        "REPO=" "base",
+        "OWNER=" "tkosht",
+        "repos/tkosht/" "base",
+    ):
+        if forbidden in text:
+            errors.append(
+                "bin/github_api_pr.sh must not hard-code base repo: "
+                + forbidden
+            )
+    for needle in ("GITHUB_REPOSITORY", "git config --get remote.origin.url"):
+        if needle not in text:
+            errors.append(
+                "bin/github_api_pr.sh must resolve owner/repo dynamically: "
+                + needle
+            )
 
 
 def _check_design_doc_terminology(root: Path, errors: list[str]) -> None:
@@ -708,6 +783,7 @@ def run_checks(root: Path = ROOT) -> list[str]:
     _check_primary_terminology(root, errors)
     _check_codex_shared_defaults(root, errors)
     _check_harness_resource_registry(root, errors)
+    _check_github_api_helper(root, errors)
     _check_heavy_repo_copy_guard(root, errors)
     _check_harness_autoptimizer_contract(root, errors)
     _check_non_root_design_md(root, errors)

--- a/tests/harness_autoptimizer/test_harness_autopt.py
+++ b/tests/harness_autoptimizer/test_harness_autopt.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -30,6 +31,25 @@ def _resource(
         max_changed_files=2,
         max_changed_lines=200,
     )
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.calls: list[tuple[list[str], Path, bool]] = []
+
+    def run(
+        self,
+        cmd: list[str],
+        cwd: Path,
+        *,
+        check: bool = False,
+    ) -> harness_autopt.CommandResult:
+        self.calls.append((cmd, cwd, check))
+        if cmd[:3] == ["gh", "pr", "create"]:
+            return harness_autopt.CommandResult(
+                0, "https://example.test/pull/1\n", ""
+            )
+        return harness_autopt.CommandResult(0, "", "")
 
 
 def test_load_resource_registry_includes_codex_subagent() -> None:
@@ -355,6 +375,362 @@ def test_guarded_pr_requires_explicit_opt_in() -> None:
     assert harness_autopt.is_pr_creation_allowed(resource, True) is True
 
 
+def test_create_pull_request_rejects_unconverged_review_report(
+    tmp_path: Path,
+) -> None:
+    runner = RecordingRunner()
+    resource = _resource(resource_id="harness-autoptimizer")
+    state = harness_autopt.AutoptState(
+        run_id="run-1",
+        branch="autopt/harness-autoptimizer-20260427-run1",
+        worktree=tmp_path,
+        resource_id="harness-autoptimizer",
+        goal="self-audit",
+    )
+    diff_guard = harness_autopt.DiffGuardResult(
+        ok=True,
+        changed_files=("tests/harness_autoptimizer/test_harness_autopt.py",),
+        changed_lines=1,
+    )
+    review_report = harness_autopt.ReviewReport(
+        loop_count=1,
+        findings=(),
+        convergence_conditions=("material findings unresolved",),
+        converged=False,
+        stop_reason="material findings unresolved",
+    )
+
+    with pytest.raises(RuntimeError, match="ReviewReport must be converged"):
+        harness_autopt.create_pull_request(
+            runner,
+            tmp_path,
+            state,
+            resource,
+            diff_guard,
+            "main",
+            review_report,
+            draft=True,
+        )
+
+    assert runner.calls == []
+
+
+def test_create_pull_request_includes_converged_review_report(
+    tmp_path: Path,
+) -> None:
+    runner = RecordingRunner()
+    resource = _resource(resource_id="harness-autoptimizer")
+    state = harness_autopt.AutoptState(
+        run_id="run-1",
+        branch="autopt/harness-autoptimizer-20260427-run1",
+        worktree=tmp_path,
+        resource_id="harness-autoptimizer",
+        goal="self-audit",
+    )
+    diff_guard = harness_autopt.DiffGuardResult(
+        ok=True,
+        changed_files=("tests/harness_autoptimizer/test_harness_autopt.py",),
+        changed_lines=1,
+    )
+    review_report = harness_autopt.build_review_report(
+        findings=(
+            harness_autopt.ReviewFinding(
+                id="review-gate",
+                severity="medium",
+                material=True,
+                status="fixed",
+                verification_class="test",
+                summary="PR creation requires converged review report",
+            ),
+        ),
+        loop_count=2,
+        gate_passed=True,
+        diff_guard=diff_guard,
+        self_audit_completed=True,
+    )
+
+    url = harness_autopt.create_pull_request(
+        runner,
+        tmp_path,
+        state,
+        resource,
+        diff_guard,
+        "origin/main",
+        review_report,
+        draft=True,
+    )
+
+    gh_command = runner.calls[-1][0]
+    body = gh_command[gh_command.index("--body") + 1]
+    assert url == "https://example.test/pull/1"
+    assert "--draft" in gh_command
+    assert "## Review Loop" in body
+    assert "loop count: 2" in body
+    assert "converged: true" in body
+
+
+def test_review_report_converges_when_material_findings_are_closed() -> None:
+    finding = harness_autopt.ReviewFinding(
+        id="repo-identity",
+        severity="high",
+        material=True,
+        status="fixed",
+        verification_class="validator",
+        summary="legacy repo identity removed",
+        evidence=("make doctor",),
+    )
+    diff_guard = harness_autopt.DiffGuardResult(
+        ok=True,
+        changed_files=("scripts/ci/validate_template.py",),
+        changed_lines=12,
+    )
+
+    report = harness_autopt.build_review_report(
+        findings=(finding,),
+        loop_count=2,
+        gate_passed=True,
+        diff_guard=diff_guard,
+        self_audit_completed=True,
+    )
+
+    assert harness_autopt.is_review_converged(report) is True
+    assert report.stop_reason == "converged"
+    assert "material findings resolved" in report.convergence_conditions
+
+
+def test_review_report_rejects_unresolved_material_finding() -> None:
+    finding = harness_autopt.ReviewFinding(
+        id="review-loop",
+        severity="medium",
+        material=True,
+        status="unresolved",
+        verification_class="manual_review",
+        summary="loop evidence was not recorded",
+    )
+    diff_guard = harness_autopt.DiffGuardResult(
+        ok=True,
+        changed_files=("tests/harness_autoptimizer/test_harness_autopt.py",),
+        changed_lines=8,
+    )
+
+    report = harness_autopt.build_review_report(
+        findings=(finding,),
+        loop_count=1,
+        gate_passed=True,
+        diff_guard=diff_guard,
+        self_audit_completed=True,
+    )
+
+    assert report.converged is False
+    assert report.stop_reason == "material findings unresolved"
+
+
+def test_review_report_allows_non_material_deferred_finding() -> None:
+    finding = harness_autopt.ReviewFinding(
+        id="later-cleanup",
+        severity="low",
+        material=False,
+        status="deferred",
+        verification_class="manual_review",
+        summary="follow-up cleanup can be handled separately",
+    )
+    diff_guard = harness_autopt.DiffGuardResult(
+        ok=True,
+        changed_files=("docs/ai/skills/harness-autoptimizer.md",),
+        changed_lines=4,
+    )
+
+    report = harness_autopt.build_review_report(
+        findings=(finding,),
+        loop_count=1,
+        gate_passed=True,
+        diff_guard=diff_guard,
+        self_audit_completed=True,
+    )
+
+    assert report.converged is True
+
+
+def test_proactive_review_probe_detects_non_target_resource_issue(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target"
+    adjacent = tmp_path / "adjacent"
+    target.mkdir()
+    adjacent.mkdir()
+    (target / "SKILL.md").write_text("current target\n", encoding="utf-8")
+    (adjacent / "SKILL.md").write_text(
+        "docs/architecture/base-" + "harness-set.md\n",
+        encoding="utf-8",
+    )
+    resources = {
+        "harness-autoptimizer": harness_autopt.HarnessResource(
+            id="harness-autoptimizer",
+            kind="skill",
+            authority="canonical",
+            paths=("target",),
+            mutable_paths=("target",),
+            validators=("make test",),
+        ),
+        "codex-subagent": harness_autopt.HarnessResource(
+            id="codex-subagent",
+            kind="skill",
+            authority="canonical",
+            paths=("adjacent",),
+            mutable_paths=("adjacent",),
+            validators=("make test",),
+        ),
+    }
+    probe = harness_autopt.ProactiveReviewProbe(
+        id="deleted-reference",
+        summary="deleted reference remains in registry resource",
+        needles=("docs/architecture/base-" + "harness-set.md",),
+    )
+
+    findings = harness_autopt.run_proactive_review_probes(
+        tmp_path,
+        resources,
+        (probe,),
+        target_resource_id="harness-autoptimizer",
+    )
+    report = harness_autopt.build_review_report(
+        findings=findings,
+        loop_count=1,
+        gate_passed=True,
+        diff_guard=harness_autopt.DiffGuardResult(
+            ok=True,
+            changed_files=("target/SKILL.md",),
+            changed_lines=1,
+        ),
+        self_audit_completed=True,
+    )
+
+    assert len(findings) == 1
+    assert findings[0].status == "out_of_scope"
+    assert findings[0].material is True
+    assert "resource=codex-subagent" in findings[0].evidence
+    assert report.converged is False
+    assert report.stop_reason == "material findings unresolved"
+
+
+def test_proactive_review_probe_marks_target_issue_unresolved(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    (target / "SKILL.md").write_text("legacy marker\n", encoding="utf-8")
+    resources = {
+        "harness-autoptimizer": harness_autopt.HarnessResource(
+            id="harness-autoptimizer",
+            kind="skill",
+            authority="canonical",
+            paths=("target",),
+            mutable_paths=("target",),
+            validators=("make test",),
+        )
+    }
+    probe = harness_autopt.ProactiveReviewProbe(
+        id="legacy-marker",
+        summary="legacy marker remains",
+        needles=("legacy marker",),
+    )
+
+    findings = harness_autopt.run_proactive_review_probes(
+        tmp_path,
+        resources,
+        (probe,),
+        target_resource_id="harness-autoptimizer",
+    )
+
+    assert len(findings) == 1
+    assert findings[0].status == "unresolved"
+
+
+def test_proactive_review_probe_respects_resource_excluded_paths(
+    tmp_path: Path,
+) -> None:
+    active = tmp_path / "docs" / "active"
+    excluded = tmp_path / "docs" / "decision-records"
+    active.mkdir(parents=True)
+    excluded.mkdir(parents=True)
+    (active / "current.md").write_text("current docs\n", encoding="utf-8")
+    (excluded / "historical.md").write_text(
+        "docs/architecture/base-" + "harness-set.md\n",
+        encoding="utf-8",
+    )
+    resources = {
+        "knowledge-docs": harness_autopt.HarnessResource(
+            id="knowledge-docs",
+            kind="knowledge_docs",
+            authority="canonical",
+            paths=("docs",),
+            mutable_paths=("docs",),
+            validators=("make test",),
+            excluded_paths=("docs/decision-records",),
+        )
+    }
+    probe = harness_autopt.ProactiveReviewProbe(
+        id="deleted-reference",
+        summary="deleted reference remains in registry resource",
+        needles=("docs/architecture/base-" + "harness-set.md",),
+    )
+
+    findings = harness_autopt.run_proactive_review_probes(
+        tmp_path,
+        resources,
+        (probe,),
+        target_resource_id="knowledge-docs",
+    )
+
+    assert findings == ()
+
+
+def test_review_finding_uses_verification_class_not_command() -> None:
+    finding = harness_autopt.ReviewFinding(
+        id="validator-coverage",
+        severity="medium",
+        material=True,
+        status="fixed",
+        verification_class="test",
+        summary="regression is covered by a test class",
+    )
+
+    assert finding.verification_class == "test"
+    assert not hasattr(finding, "command")
+
+
+def test_write_review_report_omits_raw_trace_payloads(tmp_path: Path) -> None:
+    finding = harness_autopt.ReviewFinding(
+        id="raw-trace",
+        severity="high",
+        material=True,
+        status="fixed",
+        verification_class="manual_review",
+        summary="raw_prompt SECRET_PROMPT",
+        evidence=("raw_output=RAW_MODEL_OUTPUT", "safe evidence"),
+    )
+    report = harness_autopt.build_review_report(
+        findings=(finding,),
+        loop_count=1,
+        gate_passed=True,
+        diff_guard=harness_autopt.DiffGuardResult(
+            ok=True,
+            changed_files=("README.md",),
+            changed_lines=1,
+        ),
+        self_audit_completed=True,
+    )
+
+    path = harness_autopt.write_review_report(tmp_path, "run-1", report)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    raw_json = json.dumps(payload)
+
+    assert payload["findings"][0]["summary"] == "[omitted raw trace]"
+    assert "safe evidence" in payload["findings"][0]["evidence"]
+    assert "SECRET_PROMPT" not in raw_json
+    assert "RAW_MODEL_OUTPUT" not in raw_json
+
+
 def test_build_pr_body_omits_raw_prompt_and_output() -> None:
     resource = harness_autopt.HarnessResource(
         id="codex-subagent",
@@ -388,6 +764,106 @@ def test_build_pr_body_omits_raw_prompt_and_output() -> None:
     assert "run-1" in body
     assert "SECRET_PROMPT" not in body
     assert "`make test`: pass" in body
+
+
+def test_build_pr_body_includes_review_loop_summary() -> None:
+    resource = harness_autopt.HarnessResource(
+        id="harness-autoptimizer",
+        kind="skill",
+        authority="canonical",
+        paths=("x",),
+        mutable_paths=("x",),
+        validators=("make test",),
+    )
+    state = harness_autopt.AutoptState(
+        run_id="run-1",
+        branch="autopt/harness-autoptimizer-20260424-run1",
+        worktree=Path("/tmp/worktree"),
+        resource_id="harness-autoptimizer",
+        goal="self-audit",
+    )
+    report = harness_autopt.build_review_report(
+        findings=(
+            harness_autopt.ReviewFinding(
+                id="loop-report",
+                severity="medium",
+                material=True,
+                status="fixed",
+                verification_class="test",
+                summary="review loop is structured",
+            ),
+        ),
+        loop_count=3,
+        gate_passed=True,
+        diff_guard=harness_autopt.DiffGuardResult(
+            ok=True,
+            changed_files=(
+                "tests/harness_autoptimizer/test_harness_autopt.py",
+            ),
+            changed_lines=20,
+        ),
+        self_audit_completed=True,
+    )
+
+    body = harness_autopt.build_pr_body(
+        state=state,
+        resource=resource,
+        diff_guard=harness_autopt.DiffGuardResult(
+            ok=True,
+            changed_files=(
+                "tests/harness_autoptimizer/test_harness_autopt.py",
+            ),
+            changed_lines=20,
+        ),
+        gate_commands=("make test",),
+        review_report=report,
+    )
+
+    assert "## Review Loop" in body
+    assert "loop count: 3" in body
+    assert "finding status: fixed: 1" in body
+
+
+def test_build_pr_body_omits_raw_trace_from_review_stop_reason() -> None:
+    resource = harness_autopt.HarnessResource(
+        id="harness-autoptimizer",
+        kind="skill",
+        authority="canonical",
+        paths=("x",),
+        mutable_paths=("x",),
+        validators=("make test",),
+    )
+    state = harness_autopt.AutoptState(
+        run_id="run-1",
+        branch="autopt/harness-autoptimizer-20260424-run1",
+        worktree=Path("/tmp/worktree"),
+        resource_id="harness-autoptimizer",
+        goal="self-audit",
+    )
+    report = harness_autopt.ReviewReport(
+        loop_count=1,
+        findings=(),
+        convergence_conditions=("raw traces omitted",),
+        converged=False,
+        stop_reason="raw_output SECRET_PROMPT",
+    )
+
+    body = harness_autopt.build_pr_body(
+        state=state,
+        resource=resource,
+        diff_guard=harness_autopt.DiffGuardResult(
+            ok=True,
+            changed_files=(
+                "tests/harness_autoptimizer/test_harness_autopt.py",
+            ),
+            changed_lines=20,
+        ),
+        gate_commands=("make test",),
+        review_report=report,
+    )
+
+    assert "[omitted raw trace]" in body
+    assert "SECRET_PROMPT" not in body
 
 
 def test_autopt_state_omits_raw_prompt_and_output_payloads() -> None:

--- a/tests/test_base_harness_set.py
+++ b/tests/test_base_harness_set.py
@@ -39,6 +39,7 @@ def test_harness_resource_registry_covers_retained_autoptimizer() -> None:
     assert "instruction-surface" in resource_ids
     assert "knowledge-docs" in resource_ids
     assert "project-docs" in resource_ids
+    assert "repo-template-specializer" in resource_ids
     assert "test-performance" in resource_ids
 
 

--- a/tests/test_template_contract.py
+++ b/tests/test_template_contract.py
@@ -318,6 +318,62 @@ def test_template_contract_checks_fail_when_autopt_workflow_missing_codex_agent(
     )
 
 
+def test_template_contract_checks_fail_when_autopt_review_contract_is_missing(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_repo(tmp_path)
+    skill = repo / ".claude" / "skills" / "harness-autoptimizer" / "SKILL.md"
+    skill.write_text(
+        skill.read_text(encoding="utf-8").replace(
+            "ReviewReport", "StructuredReviewRemoved"
+        ),
+        encoding="utf-8",
+    )
+
+    errors = run_checks(repo)
+
+    assert (
+        ".claude/skills/harness-autoptimizer/SKILL.md "
+        "missing controller contract: ReviewReport"
+    ) in errors
+
+
+def test_template_contract_checks_fail_when_github_helper_targets_base(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_repo(tmp_path)
+    helper = repo / "bin" / "github_api_pr.sh"
+    helper.write_text(
+        "#!/usr/bin/env bash\nOWNER=" + "tkosht\nREPO=" + "base\n",
+        encoding="utf-8",
+    )
+
+    errors = run_checks(repo)
+
+    assert (
+        "bin/github_api_pr.sh must not hard-code base repo: REPO=" + "base"
+    ) in errors
+
+
+def test_template_contract_checks_fail_when_github_helper_is_not_dynamic(
+    tmp_path: Path,
+) -> None:
+    repo = _copy_repo(tmp_path)
+    helper = repo / "bin" / "github_api_pr.sh"
+    text = helper.read_text(encoding="utf-8")
+    helper.write_text(
+        text.replace("GITHUB_REPOSITORY", "GH_REPOSITORY_REMOVED"),
+        encoding="utf-8",
+    )
+
+    errors = run_checks(repo)
+
+    assert (
+        "bin/github_api_pr.sh must resolve owner/repo dynamically: "
+        "GITHUB_REPOSITORY"
+    ) in errors
+
+
 def test_template_contract_checks_fail_when_grill_me_doc_is_missing(
     tmp_path: Path,
 ) -> None:
@@ -342,7 +398,8 @@ def test_template_contract_checks_fail_when_grill_me_skill_dir_is_missing(
         "unexpected .claude/skills layout: ai-agent-collaboration-exec, "
         "codex-subagent, git-commit-pr, git-mainbranch, "
         "grill-me-essential-first, harness-autoptimizer, "
-        "repo-instruction-optimizer, skill-authoring"
+        "repo-instruction-optimizer, repo-template-specializer, "
+        "skill-authoring"
     ) in errors
 
 
@@ -371,7 +428,8 @@ def test_template_contract_checks_fail_when_grill_me_essential_first_skill_dir_i
     assert (
         "unexpected .claude/skills layout: ai-agent-collaboration-exec, "
         "codex-subagent, git-commit-pr, git-mainbranch, grill-me, "
-        "harness-autoptimizer, repo-instruction-optimizer, skill-authoring"
+        "harness-autoptimizer, repo-instruction-optimizer, "
+        "repo-template-specializer, skill-authoring"
     ) in errors
 
 
@@ -386,7 +444,8 @@ def test_template_contract_checks_fail_when_grill_me_essential_first_agent_entry
     assert (
         "unexpected .agents/skills layout: ai-agent-collaboration-exec, "
         "codex-subagent, git-commit-pr, git-mainbranch, grill-me, "
-        "harness-autoptimizer, repo-instruction-optimizer, skill-authoring"
+        "harness-autoptimizer, repo-instruction-optimizer, "
+        "repo-template-specializer, skill-authoring"
     ) in errors
 
 
@@ -401,7 +460,8 @@ def test_template_contract_checks_fail_when_grill_me_essential_first_codex_entry
     assert (
         "unexpected .codex/skills layout: ai-agent-collaboration-exec, "
         "codex-subagent, git-commit-pr, git-mainbranch, grill-me, "
-        "harness-autoptimizer, repo-instruction-optimizer, skill-authoring"
+        "harness-autoptimizer, repo-instruction-optimizer, "
+        "repo-template-specializer, skill-authoring"
     ) in errors
 
 


### PR DESCRIPTION
## Summary

- Add `repo-template-specializer` so generated repos can slim and specialize base-template residue with a reusable checklist.
- Extend `harness-autoptimizer` with `ReviewFinding`, `ProactiveReviewProbe`, and converged `ReviewReport` gating before PR creation.
- Harden base template validation for structured review contracts, new skill discovery, and dynamic GitHub owner/repo resolution.

## Review Loop

- loop count: 2
- converged: true
- finding status: fixed: 2
- stop reason: converged

## Validation

- `make doctor`: pass
- `make lint`: pass
- `make test`: pass
- `git diff --check`: pass
- `bash -n bin/github_api_pr.sh`: pass

Raw prompts, raw model outputs, secrets, and runtime logs are intentionally omitted.